### PR TITLE
Add (optional) proxy history on the front page.

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -139,7 +139,7 @@ def md_series_data(series_id):
             data = {
                 "slug": series_id, "title": api_data["manga"]["title"], "description": api_data["manga"]["description"], 
                 "author": api_data["manga"]["author"], "artist": api_data["manga"]["artist"], "groups": groups_dict,
-                "cover": api_data["manga"]["cover_url"], "preferred_sort": settings.PREFERRED_SORT, "chapters": chapters_dict
+                "cover": "https://mangadex.org" + api_data["manga"]["cover_url"], "preferred_sort": settings.PREFERRED_SORT, "chapters": chapters_dict
             }
             cache.set(f"md_series_dt_{series_id}", data, 3600 * 24)
         else:

--- a/homepage/templates/homepage/home.html
+++ b/homepage/templates/homepage/home.html
@@ -316,7 +316,7 @@
 		<div id="quote-block" class="col-lg-8 col-md-8 col-sm-8 col-xs-8 text-center">
 		</div>
 		<div class="col-lg-2 col-md-2 col-sm-2 col-xs-2 float-right">
-			<img class="img-fluid mx-auto d-block" style="height: 75px; width: 56px; float:right"
+			<img id="twintail-guya" class="img-fluid mx-auto d-block" style="height: 75px; width: 56px; float:right"
 				src="{% static 'img/img_comics-bottom.png' %}">
 		</div>
 	</div>

--- a/reader/templates/reader/reader.html
+++ b/reader/templates/reader/reader.html
@@ -40,6 +40,7 @@
 		<link rel="stylesheet" type="text/css" href="{% static 'css/main.css' %}{{ version_query }}">
 		<link rel="shortcut icon" type="image/png" href="{% static 'favicon.ico' %}"/>
 		{% include "referral.html" %}
+		{% include "proxy_history.html" %}
 	</head>
 	
 <body>

--- a/reader/views.py
+++ b/reader/views.py
@@ -152,7 +152,7 @@ def reader(request, series_slug, chapter, page=None):
 def md_proxy(request, md_series_id):
     metadata = md_series_page_data(md_series_id)
     if metadata:
-        metadata["relative_url"] = f"md_proxy/{md_series_id}"
+        metadata["relative_url"] = f"read/md_proxy/{md_series_id}"
         metadata["version_query"] = STATIC_VERSION
         return render(request, 'reader/md_series.html', metadata)
     else:
@@ -162,7 +162,7 @@ def md_proxy(request, md_series_id):
 def md_chapter(request, md_series_id, chapter, page):
     data = md_series_data(md_series_id)
     if data and chapter.replace("-", ".") in data["chapters"]:
-        data["relative_url"] = f"md_proxy/{md_series_id}/{chapter}/{page}"
+        data["relative_url"] = f"read/md_proxy/{md_series_id}/{chapter}/{page}"
         data["hide_referrer"] = True
         data["version_query"] = STATIC_VERSION
         return render(request, 'reader/reader.html', data)
@@ -173,7 +173,7 @@ def md_chapter(request, md_series_id, chapter, page):
 def nh_proxy(request, nh_series_id):
     metadata = nh_series_data(nh_series_id)
     if metadata:
-        metadata["relative_url"] = f"nh_proxy/{nh_series_id}"
+        metadata["relative_url"] = f"read/nh_proxy/{nh_series_id}"
         metadata["version_query"] = STATIC_VERSION
         return render(request, 'reader/nh_series.html', metadata)
     else:
@@ -183,7 +183,7 @@ def nh_proxy(request, nh_series_id):
 def nh_chapter(request, nh_series_id, chapter, page):
     data = nh_series_data(nh_series_id)
     if data and chapter.replace("-", ".") in data["chapters"]:
-        data["relative_url"] = f"nh_proxy/{nh_series_id}/{chapter}/{page}"
+        data["relative_url"] = f"read/nh_proxy/{nh_series_id}/{chapter}/{page}"
         data["hide_referrer"] = True
         data["version_query"] = STATIC_VERSION
         return render(request, 'reader/reader.html', data)
@@ -194,7 +194,7 @@ def nh_chapter(request, nh_series_id, chapter, page):
 def fs_proxy(request, encoded_url):
     metadata = fs_series_page_data(encoded_url)
     if metadata:
-        metadata["relative_url"] = f"fs_proxy/{encoded_url}"
+        metadata["relative_url"] = f"read/fs_proxy/{encoded_url}"
         metadata["version_query"] = STATIC_VERSION
         return render(request, 'reader/fs_series.html', metadata)
     else:
@@ -204,7 +204,7 @@ def fs_proxy(request, encoded_url):
 def fs_chapter(request, encoded_url, chapter, page):
     data = fs_series_data(encoded_url)
     if data and chapter.replace("-", ".") in data["chapters"]:
-        data["relative_url"] = f"fs_proxy/{encoded_url}/{chapter}/{page}"
+        data["relative_url"] = f"read/fs_proxy/{encoded_url}/{chapter}/{page}"
         data["hide_referrer"] = True
         data["version_query"] = STATIC_VERSION
         return render(request, 'reader/reader.html', data)

--- a/static_global/css/index.css
+++ b/static_global/css/index.css
@@ -536,6 +536,12 @@ main a {
 	content: unset;
 }
 
+.manga-card.proxy picture img {
+	max-width: 6.5rem;
+	min-width: 6.5rem;
+	object-fit: cover;
+}
+
 .manga-link {
 	display: inline-block;
 	padding: 0.4em 1em 0.5em 0.75em;

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -56,6 +56,7 @@
 		}
 	</style>
 	{% include "referral.html" %}
+	{% include "proxy_history.html" %}
 </head>
 
 <body class="d-flex flex-column h-100">

--- a/templates/proxy_history.html
+++ b/templates/proxy_history.html
@@ -97,7 +97,7 @@
       .querySelector("[role='main']")
       .insertAdjacentHTML(
         "beforeend",
-        "<h1 class='proxy' style='width:100%'>Proxy History</h1>"
+        "<h3 class='proxy' style='width:100%; padding-left:1rem;'>Proxy History</h3>"
       );
     let items = proxyHistoryHandler.getItems();
     if (items.length) {

--- a/templates/proxy_history.html
+++ b/templates/proxy_history.html
@@ -124,7 +124,12 @@
               <br>
               <h4>FoolSlide Sites</h4>
               <p>Append the FoolSlide site's URL to the end of <code>https://guya.moe/fs/</code>. For example, <code>https://jaiminisbox.com/reader/series/kaguya-wants-to-be-confessed-to</code> becomes <code>https://guya.moe/fs/https://jaiminisbox.com/reader/series/kaguya-wants-to-be-confessed-to</code>.</p>
-              <br>
+              <p>Some FoolSlide enabled sites include:</p>
+              <ul>
+                <li><code>https://hentai.cafe/</code></li>
+                <li><code>https://jaiminisbox.com/</code></li>
+                <li><code>https://helveticascans.com/</code></li>
+              </ul>
               <p>Once you start reading, this card will disappear and this section will fill up with your last <strong>${proxyHistoryHandler.max}</strong> series.</p>
               <p>You can also disable/enable this history feature at any time by clicking on the twintail Kaguya ${MAX_CLICKS} times. Note that it'll clear your history each time.</p>
               <p><i>Got a suggestion on how we could improve this feature? Use the feedback box with the envelope symbol on your top left!</i></p>

--- a/templates/proxy_history.html
+++ b/templates/proxy_history.html
@@ -83,11 +83,6 @@
 
   let deleteItem = (event, element, proxySource, slug) => {
     event.preventDefault();
-    if (event.stopPropagation) {
-      event.stopPropagation();
-    } else {
-      event.cancelBubble = true;
-    }
     proxyHistoryHandler.deleteItem(proxySource, slug);
     element.parentElement.parentElement.parentElement.remove();
   };

--- a/templates/proxy_history.html
+++ b/templates/proxy_history.html
@@ -1,5 +1,6 @@
 <meta name="referrer" content="no-referrer" />
 <script>
+  let MAX_CLICKS = 7;
   // Realistically, any browser that supports localStorage will
   // support arrow functions so tough luck, IE
   // This IIFE will act as a disgusting LRU cache
@@ -131,7 +132,7 @@
               <p>Append the FoolSlide site's URL to the end of <code>https://guya.moe/fs/</code>. For example, <code>https://jaiminisbox.com/reader/series/kaguya-wants-to-be-confessed-to</code> becomes <code>https://guya.moe/fs/https://jaiminisbox.com/reader/series/kaguya-wants-to-be-confessed-to</code>.</p>
               <br>
               <p>Once you start reading, this card will disappear and this section will fill up with your last <strong>${proxyHistoryHandler.max}</strong> series.</p>
-              <p>You can also disable/enable this history feature at any time by clicking on the twintail Kaguya again. Note that it'll clear your history each time.</p>
+              <p>You can also disable/enable this history feature at any time by clicking on the twintail Kaguya ${MAX_CLICKS} times. Note that it'll clear your history each time.</p>
               <p><i>Got a suggestion on how we could improve this feature? Use the feedback box with the envelope symbol on your top left!</i></p>
           </article>
         </div>`
@@ -185,15 +186,23 @@
   } else if (window.location.pathname === "/") {
     window.addEventListener("load", () => {
       let enabled = proxyHistoryHandler.enabled();
-      document.getElementById("twintail-guya").addEventListener("click", () => {
-        if (enabled) {
-          proxyHistoryHandler.history.disable();
-          proxyDestroyElements();
+      let clicked = 0;
+      document.getElementById("twintail-guya").addEventListener("click", (e) => {
+        if (clicked < MAX_CLICKS) {
+          clicked++;
+          (e.target || e.srcElement).style.opacity = `${1 - clicked / 10}`;
         } else {
-          proxyHistoryHandler.history.enable();
-          proxyInitElements();
+          (e.target || e.srcElement).style.opacity = "1";
+          clicked = 0;
+          if (enabled) {
+            proxyHistoryHandler.history.disable();
+            proxyDestroyElements();
+          } else {
+            proxyHistoryHandler.history.enable();
+            proxyInitElements();
+          }
+          enabled = !enabled;
         }
-        enabled = !enabled;
       });
       if (enabled) {
         proxyInitElements();

--- a/templates/proxy_history.html
+++ b/templates/proxy_history.html
@@ -23,27 +23,21 @@
 
     let deleteItem = (proxySource, slug) => {
       let items = getItems();
-      let idx = items.findIndex(
-        (e) => e.slug === slug && e.proxySource === proxySource
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify(items.filter((e) =>
+          e.slug !== slug || e.proxySource !== proxySource
+        ))
       );
-      if (idx !== -1) {
-        items.splice(idx, 1);
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
-      }
     };
 
     let pushItem = (coverUrl, proxySource, slug, url, title) => {
       if (enabled()) {
-        let items = getItems();
-        let idx = items.findIndex(
-          (e) => e.slug === slug && e.proxySource === proxySource
+        let items = getItems().filter((e) =>
+          e.slug !== slug || e.proxySource !== proxySource
         );
-        if (idx !== -1) {
-          items.splice(idx, 1);
-        } else {
-          if (items.length + 1 > MAX_VALUES) {
-            items.pop();
-          }
+        if (items.length + 1 > MAX_VALUES) {
+          items.pop();
         }
         localStorage.setItem(
           STORAGE_KEY,

--- a/templates/proxy_history.html
+++ b/templates/proxy_history.html
@@ -1,0 +1,208 @@
+<meta name="referrer" content="no-referrer" />
+<script>
+  // Realistically, any browser that supports localStorage will
+  // support arrow functions so tough luck, IE
+  // This IIFE will act as a disgusting LRU cache
+  let proxyHistoryHandler = (() => {
+    let STORAGE_KEY = "proxyHistory";
+    let MAX_VALUES = 10;
+
+    let enabled = () => {
+      return localStorage.getItem(STORAGE_KEY) ? true : false;
+    };
+
+    let getItems = () => {
+      let items = localStorage.getItem(STORAGE_KEY);
+      if (items) {
+        return JSON.parse(items);
+      } else {
+        return [];
+      }
+    };
+
+    let deleteItem = (proxySource, slug) => {
+      let items = getItems();
+      let idx = items.findIndex(
+        (e) => e.slug === slug && e.proxySource === proxySource
+      );
+      if (idx !== -1) {
+        items.splice(idx, 1);
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+      }
+    };
+
+    let pushItem = (coverUrl, proxySource, slug, url, title) => {
+      if (enabled()) {
+        let items = getItems();
+        let idx = items.findIndex(
+          (e) => e.slug === slug && e.proxySource === proxySource
+        );
+        if (idx !== -1) {
+          items.splice(idx, 1);
+        } else {
+          if (items.length + 1 > MAX_VALUES) {
+            items.pop();
+          }
+        }
+        localStorage.setItem(
+          STORAGE_KEY,
+          JSON.stringify([
+            {
+              coverUrl: coverUrl,
+              proxySource: proxySource,
+              slug: slug,
+              url: url,
+              title: title,
+            },
+            ...items,
+          ])
+        );
+      }
+    };
+
+    let enableHistory = () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify([]));
+    };
+
+    let disableHistory = () => {
+      localStorage.removeItem(STORAGE_KEY);
+    };
+
+    return {
+      enabled: enabled,
+      getItems: getItems,
+      deleteItem: deleteItem,
+      pushItem: pushItem,
+      history: {
+        enable: enableHistory,
+        disable: disableHistory,
+      },
+      max: MAX_VALUES,
+    };
+  })();
+
+  let deleteItem = (event, element, proxySource, slug) => {
+    event.preventDefault();
+    if (event.stopPropagation) {
+      event.stopPropagation();
+    } else {
+      event.cancelBubble = true;
+    }
+    proxyHistoryHandler.deleteItem(proxySource, slug);
+    element.parentElement.parentElement.parentElement.remove();
+  };
+
+  let proxyDestroyElements = () => {
+    document.querySelectorAll(".proxy").forEach(e => e.remove());
+  }
+
+  let proxyInitElements = () => {
+    document
+      .querySelector("[role='main']")
+      .insertAdjacentHTML(
+        "beforeend",
+        "<h1 class='proxy' style='width:100%'>Proxy History</h1>"
+      );
+    let items = proxyHistoryHandler.getItems();
+    if (items.length) {
+      items.forEach((item) => {
+        document.querySelector("[role='main']").insertAdjacentHTML(
+          "beforeend",
+          `<a href="${item.url}" class="manga-card smol proxy" style="background-image: url('${item.coverUrl}')">
+            <picture>
+              <img src="${item.coverUrl}">
+            </picture>
+            <article>
+              <h2>${item.title} <span class="tag">${item.proxySource}</span> <i class="fa fa-trash" onclick="deleteItem(event, this, '${item.proxySource}', '${item.slug}');"></i></h2>
+            </article>
+          </a>`
+        );
+      });
+    } else {
+      document.querySelector("[role='main']").insertAdjacentHTML(
+        "beforeend",
+        `<div class="manga-card proxy" style="width:100%">
+          <article>
+              <p>Looks like you haven't used the proxy yet! This card will give you a short tutorial about how it works.</p>
+              <p>Note that your history is unique to your browser session, and won't be shared with guya.moe. If you clear your cache then your history will disappear.</p>
+              <br>
+              <h4>MangaDex</h4>
+              <p>Replace <code>mangadex.org</code> in the URL with <code>guya.moe</code>. For example, <code>https://mangadex.org/title/17274/</code> becomes <code>https://guya.moe/title/17274/</code>.</p>
+              <br>
+              <h4>NHentai</h4>
+              <p>Replace <code>nhentai.net</code> in the URL with <code>guya.moe</code>. For example, <code>https://nhentai.net/g/1/</code> becomes <code>https://guya.moe/g/1/</code>.</p>
+              <br>
+              <h4>FoolSlide Sites</h4>
+              <p>Append the FoolSlide site's URL to the end of <code>https://guya.moe/fs/</code>. For example, <code>https://jaiminisbox.com/reader/series/kaguya-wants-to-be-confessed-to</code> becomes <code>https://guya.moe/fs/https://jaiminisbox.com/reader/series/kaguya-wants-to-be-confessed-to</code>.</p>
+              <br>
+              <p>Once you start reading, this card will disappear and this section will fill up with your last <strong>${proxyHistoryHandler.max}</strong> series.</p>
+              <p>You can also disable/enable this history feature at any time by clicking on the twintail Kaguya again. Note that it'll clear your history each time.</p>
+              <p><i>Got a suggestion on how we could improve this feature? Use the feedback box with the envelope symbol on your top left!</i></p>
+          </article>
+        </div>`
+      );
+    }
+  };
+
+  if (window.location.pathname.includes("proxy/")) {
+    if (proxyHistoryHandler.enabled()) {
+      try {
+        {% if cover_vol_url %}
+          let coverUrl = "{{ cover_vol_url }}";
+        {% elif cover %}
+          let coverUrl = "{{ cover }}";
+        {% else %}
+          let coverUrl = "";
+        {% endif %}
+
+        let proxySource = window.location.pathname
+          .split("/")
+          .find((e) => e.includes("proxy"))
+          .replace("_", " ");
+
+        {% if slug %}
+          let slug = "{{ slug }}";
+        {% else %}
+          let slug = "";
+        {% endif %}
+
+        {% if relative_url %}
+          let url = "{{ relative_url }}".split(slug)[0] + slug;
+        {% else %}
+          let url = "";
+        {% endif %}
+
+        {% if series %}
+          let title = "{{ series }}";
+        {% elif title %}
+          let title = "{{ title }}";
+        {% else %}
+          let title = "";
+        {% endif %}
+
+        if (coverUrl && proxySource && slug && url && title) {
+          proxyHistoryHandler.pushItem(coverUrl, proxySource, slug, url, title);
+        }
+      } catch (e) {
+        console.log("Failed pushing history", e);
+      }
+    }
+  } else if (window.location.pathname === "/") {
+    window.addEventListener("load", () => {
+      let enabled = proxyHistoryHandler.enabled();
+      document.getElementById("twintail-guya").addEventListener("click", () => {
+        if (enabled) {
+          proxyHistoryHandler.history.disable();
+          proxyDestroyElements();
+        } else {
+          proxyHistoryHandler.history.enable();
+          proxyInitElements();
+        }
+        enabled = !enabled;
+      });
+      if (enabled) {
+        proxyInitElements();
+      }
+    });
+  }
+</script>

--- a/templates/proxy_history.html
+++ b/templates/proxy_history.html
@@ -175,7 +175,7 @@
           let title = "";
         {% endif %}
 
-        if (coverUrl && proxySource && slug && url && title) {
+        if (proxySource && slug && url && title) {
           proxyHistoryHandler.pushItem(coverUrl, proxySource, slug, url, title);
         }
       } catch (e) {


### PR DESCRIPTION
s2 hype == work on things that don't actually help guya. 

This change adds a toggle to enable showing a user's proxy history. Clicking/tapping the twintail guya in the corner enables/disables the proxy history and shows it listed by the last 10 viewed, ordered by view date.

http://ec2-18-191-228-67.us-east-2.compute.amazonaws.com/

Click on the twintail guya 7 times, then use the proxy:
[md](http://ec2-18-191-228-67.us-east-2.compute.amazonaws.com/title/17274/)
[jb](http://ec2-18-191-228-67.us-east-2.compute.amazonaws.com/fs/https://jaiminisbox.com/reader/series/kaguya-wants-to-be-confessed-to)
[nh](http://ec2-18-191-228-67.us-east-2.compute.amazonaws.com/g/276722/)
[helvetica](http://ec2-18-191-228-67.us-east-2.compute.amazonaws.com/fs/https://helveticascans.com/r/series/zombie-100/)
[more md](http://ec2-18-191-228-67.us-east-2.compute.amazonaws.com/title/33275/she-doesn-t-know-why-she-lives)
[even more md](http://ec2-18-191-228-67.us-east-2.compute.amazonaws.com/title/42490)

etc. something something unit tests