### PR TITLE
Bandaid for FF last page scrolling.

### DIFF
--- a/reader/static/js/init.js
+++ b/reader/static/js/init.js
@@ -2543,3 +2543,8 @@ function debug() {
 	el.id = 'test_element';
 	document.getElementsByClassName('rdr-image-wrap')[0].appendChild(el)
 }
+
+// This is a hacky fix that prevents the last div of a
+// flexbox from not receiving the scroll event from a
+// mousewheel. Probably requires some more investigation.
+window.addEventListener("wheel", () => {});


### PR DESCRIPTION
For future reference:
- Bug seems to not propagate the scroll event properly to the nested div: giving the body an overflow will demonstrate that when the bug occurs, the body will scroll rather than the nested imageWrapper. 