### PR TITLE
Meta tags, FoolSlide API.

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -374,7 +374,7 @@ def fs_series_page_data(encoded_url):
                     volume_number = volume_regex.group(2)
                 chapter_title = link.get_text()
                 upload_info = a.find("div", class_="meta_r").get_text()
-                chapter_list.append([chapter_number, chapter_title, link["href"], upload_info])
+                chapter_list.append([chapter_number, chapter_number.replace(".", "-"), chapter_title, link["href"], upload_info])
 
             data = {
                 "series": title,

--- a/api/api.py
+++ b/api/api.py
@@ -363,11 +363,11 @@ def fs_series_page_data(encoded_url):
 
             for a in soup.find_all("div", class_="element"):
                 link = a.find("div", class_="title").find("a")
-                chapter_regex = re.search(r'(Chapter |Ch.)(\d+)', link.get_text())
+                chapter_regex = re.search(r'(Chapter |Ch.)([\d.]+)', link.get_text())
                 chapter_number = "0"
                 if chapter_regex:
                     chapter_number = chapter_regex.group(2)
-                volume_regex = re.search(r'(Volume |Vol.)(\d+)', link.get_text())
+                volume_regex = re.search(r'(Volume |Vol.)([\d.]+)', link.get_text())
                 volume_number = "1"
                 if volume_regex:
                     volume_number = volume_regex.group(2)
@@ -414,11 +414,11 @@ def fs_series_data(encoded_url):
 
             for a in soup.find_all("div", class_="element"):
                 link = a.find("div", class_="title").find("a")
-                chapter_regex = re.search(r'(Chapter |Ch.)(\d+)', link.get_text())
+                chapter_regex = re.search(r'(Chapter |Ch.)([\d.]+)', link.get_text())
                 chapter_number = "0"
                 if chapter_regex:
                     chapter_number = chapter_regex.group(2)
-                volume_regex = re.search(r'(Volume |Vol.)(\d+)', link.get_text())
+                volume_regex = re.search(r'(Volume |Vol.)([\d.]+)', link.get_text())
                 volume_number = "1"
                 if volume_regex:
                     volume_number = volume_regex.group(2)

--- a/api/urls.py
+++ b/api/urls.py
@@ -8,7 +8,7 @@ urlpatterns = [
     re_path(r'^nh_series/(?P<series_id>[\d]{1,9})/$', views.get_nh_series_data, name='api-nh_series_data'),
     re_path(r'^fs_encode_url/(?P<raw_url>[\w\d\/:.-]+)', views.get_fs_encoded_url, name='api-fs_encoded_url'),
     re_path(r'^fs_series/(?P<encoded_url>[\w\d.%-]+)/', views.get_fs_series_data, name='api-fs_series_data'),
-    re_path(r'^fs_chapter_pages/(?P<encoded_url>[\w\d.%-]+)/', views.get_fs_chapter_pages, name='api-fs_chapter_pages'),
+    re_path(r'^fs_chapter_pages/(?P<encoded_url>[\w\d\.\:\%\-\&\=]+)/', views.get_fs_chapter_pages, name='api-fs_chapter_pages'),
     re_path(r'^get_all_series/', views.get_all_series, name='api-get-all-series'),
     re_path(r'^get_groups/(?P<series_slug>[\w-]+)/', views.get_groups, name='api-groups'),
     re_path(r'^get_all_groups/', views.get_all_groups, name='api-all-groups'),

--- a/api/views.py
+++ b/api/views.py
@@ -13,7 +13,7 @@ from django.core.cache import cache
 from django.views.decorators.http import condition
 from reader.models import Series, Volume, Chapter, Group, ChapterIndex
 from reader.users_cache_lib import get_user_ip
-from .api import all_chapter_data_etag, chapter_data_etag, series_data, md_series_data, md_chapter_info, series_data_cache, all_groups, random_chars, create_preview_pages, clear_series_cache, clear_pages_cache, zip_volume, zip_chapter, nh_series_data, fs_series_data, fs_chapter_data, fs_encode_url, fs_encode_slug, ENCODE_STR
+from .api import all_chapter_data_etag, chapter_data_etag, series_data, md_series_data, md_chapter_info, series_data_cache, all_groups, random_chars, create_preview_pages, clear_series_cache, clear_pages_cache, zip_volume, zip_chapter, nh_series_data, fs_series_data, fs_chapter_data, fs_encode_url, fs_encode_slug, ENCODE_STR_SLASH
 from django.views.decorators.csrf import csrf_exempt
 import requests
 
@@ -208,14 +208,14 @@ def black_hole_mail(request):
         return HttpResponse(json.dumps({"success": "Mail successfully crossed the event horizon"}), content_type="application/json")
 
 def get_fs_series_data(request, encoded_url):
-    if ENCODE_STR in encoded_url:
+    if ENCODE_STR_SLASH in encoded_url:
         series_api_data = fs_series_data(encoded_url)
         return HttpResponse(json.dumps(series_api_data), content_type="application/json")
     else:
         return HttpResponse(status=400)
 
 def get_fs_chapter_pages(request, encoded_url):
-    if ENCODE_STR in encoded_url:
+    if ENCODE_STR_SLASH in encoded_url:
         chapter_pages = fs_chapter_data(encoded_url)
         if chapter_pages:
             return HttpResponse(json.dumps(chapter_pages), content_type="application/json")

--- a/homepage/views.py
+++ b/homepage/views.py
@@ -105,6 +105,8 @@ def fs_gateway(request, raw_url):
         page = "1"
         if "/page/" in raw_url:
             page_idx = params.index("page")
+            if lang_idx + 3 != page_idx:
+                chapter += f"-{params[lang_idx + 3]}"
             page = params[page_idx + 1]
         return redirect('reader-fs-chapter', fs_encode_slug(raw_url), chapter, page)
     elif "/series/" in raw_url:

--- a/homepage/views.py
+++ b/homepage/views.py
@@ -99,11 +99,12 @@ def fs_gateway(request, raw_url):
         raw_url = raw_url[:-1]
     if "/read/" in raw_url:
         params = raw_url.split("/")
+        # ~~Translator~~ Developer's note: "en" means only english FS sites work
+        lang_idx = params.index("en")
+        chapter = params[lang_idx + 2]
         page = "1"
-        chapter = params[-1]
         if "/page/" in raw_url:
             page_idx = params.index("page")
-            chapter = params[page_idx - 1]
             page = params[page_idx + 1]
         return redirect('reader-fs-chapter', fs_encode_slug(raw_url), chapter, page)
     elif "/series/" in raw_url:

--- a/reader/static/js/init.js
+++ b/reader/static/js/init.js
@@ -941,11 +941,13 @@ function UI_Reader(o) {
 
 		//if last page
 		if(HAS_LOCALSTORAGE && nextWrapperIndex >= this.imageView.imageWrappersMask.length - 1){
-		let readChapters = JSON.parse(localStorage.getItem("readChapters")) || {};
-			if(!readChapters[this.SCP.series])
-				readChapters[this.SCP.series] = [];
-			if (!readChapters[this.SCP.series].includes(this.SCP.chapter))
-				readChapters[this.SCP.series].push(this.SCP.chapter)
+			let readChapters = JSON.parse(localStorage.getItem("readChapters")) || {};
+			let series = unescape(this.SCP.series);
+			let chapter = this.SCP.chapter.toString().replace(".", "-");
+			if(!readChapters[series])
+				readChapters[series] = [];
+			if (!readChapters[series].includes(chapter))
+				readChapters[series].push(chapter);
 			localStorage.setItem("readChapters", JSON.stringify(readChapters));
 		}
 		

--- a/reader/templates/reader/fs_series.html
+++ b/reader/templates/reader/fs_series.html
@@ -221,9 +221,9 @@
               </tr>
             </thead>
             <tbody id="chapterTable">
-              {% for chapter, title, link, upload_info in chapter_list %}
-              <tr class="table-default" data-chapter="{{ chapter }}" >
-              <td scope="row" class="read-icon" onclick="setRead('{{ chapter }}', this)"></td>
+              {% for chapter, ch_slug, title, link, upload_info in chapter_list %}
+              <tr class="table-default" data-chapter="{{ ch_slug }}" >
+              <td scope="row" class="read-icon" onclick="setRead('{{ ch_slug }}', this)"></td>
                 <td scope="row">
                   <a href="/fs/{{ link }}">{{ chapter }} - {{ title }}</a>
                 </td>

--- a/reader/templates/reader/reader.html
+++ b/reader/templates/reader/reader.html
@@ -8,13 +8,18 @@
 	    <meta name="twitter:title" content="{{ series_name }} - Chapter {{ chapter_number }} | Guya.moe">
 	    <meta property="og:title" content="{{ series_name }} - Chapter {{ chapter_number }} | Guya.moe">
 	    <meta name="description" content="Read chapter {{ chapter_number }} of {{ series_name }} | Guya.moe">
+		{% if first_party %}
 		<meta property="og:description" content="Read the Kaguya-sama: Love is War / Kaguya Wants to Be Confessed To manga series. No ads. No bad reader. All guya.">
 	    <meta name="twitter:description" content="Read the Kaguya-sama: Love is War / Kaguya Wants to Be Confessed To manga series. No ads. No bad reader. All guya.">
 	    <meta name="twitter:card" content="Everything Kaguya-sama">
 		<meta property="og:image" content="https://i.imgur.com/jBhT5LV.png">
 	    <meta name="twitter:image" content="https://i.imgur.com/jBhT5LV.png">
-		<meta property="og:url" content="/read/manga/{{ slug }}">
 	    <meta name="author" content="Akasaka Aka">
+		{% else %}
+		<meta property="og:description" content="Read the {{ series_name }} manga series. No ads. No bad reader. Some guya.">
+		<meta name="twitter:description" content="Read the {{ series_name }} manga series. No ads. No bad reader. Some guya.">
+		{% endif %}
+		<meta property="og:url" content="/read/manga/{{ slug }}">
 		<meta name="viewport" content="width=device-width">
 		{% if hide_referrer %}
 			<meta name="referrer" content="no-referrer">

--- a/reader/views.py
+++ b/reader/views.py
@@ -142,6 +142,7 @@ def reader(request, series_slug, chapter, page=None):
         if chapter in metadata:
             metadata[chapter]["relative_url"] = f"read/manga/{series_slug}/{chapter}/1"
             metadata[chapter]["version_query"] = STATIC_VERSION
+            metadata[chapter]["first_party"] = True
             return render(request, 'reader/reader.html', metadata[chapter])
         else:
             return render(request, 'homepage/how_cute_404.html', status=404)
@@ -165,6 +166,7 @@ def md_chapter(request, md_series_id, chapter, page):
         data["relative_url"] = f"read/md_proxy/{md_series_id}/{chapter}/{page}"
         data["hide_referrer"] = True
         data["version_query"] = STATIC_VERSION
+        data["series_name"] = data["title"]
         return render(request, 'reader/reader.html', data)
     else:
         return render(request, 'homepage/how_cute_404.html', status=404)
@@ -186,6 +188,7 @@ def nh_chapter(request, nh_series_id, chapter, page):
         data["relative_url"] = f"read/nh_proxy/{nh_series_id}/{chapter}/{page}"
         data["hide_referrer"] = True
         data["version_query"] = STATIC_VERSION
+        data["series_name"] = data["title"]
         return render(request, 'reader/reader.html', data)
     else:
         return render(request, 'homepage/how_cute_404.html', status=404)
@@ -207,6 +210,7 @@ def fs_chapter(request, encoded_url, chapter, page):
         data["relative_url"] = f"read/fs_proxy/{encoded_url}/{chapter}/{page}"
         data["hide_referrer"] = True
         data["version_query"] = STATIC_VERSION
+        data["series_name"] = data["title"]
         return render(request, 'reader/reader.html', data)
     else:
         return render(request, 'homepage/how_cute_404.html', status=404)


### PR DESCRIPTION
Gonna just leave this one in for posterity.

```python
raw_data_regex = re.search(r'(?:var _0x3320=)(?P<array>[\d\D]+?)(?:;[\d\D]+?_0x3320,)(?P<shuffle>[\d\D]+)(?:\)\);)(?:[\d\D]+\]\(\([\d\D]+?\?)(?P<iftrue>[\d\D]+?)(?:\:)(?P<iffalse>[\d\D]+?)(?:\)[\d\D]+?\+)(?P<addition>[\d\D]+?)(?:\)[\d\D]+?-)(?P<subtraction>[\d\D]+?)(?:\))', resp.text)
raw_data = raw_data_regex.group("array")
shuffle = int(raw_data_regex.group("shuffle"), 16)
if_true = int(raw_data_regex.group("iftrue"), 16)
if_false = int(raw_data_regex.group("iffalse"), 16)
add_unconditionally = int(raw_data_regex.group("addition"), 16)
sub_unconditionally = int(raw_data_regex.group("subtraction"), 16)
b64 = json.loads(raw_data.replace("\'", "\""))
b64 = b64[1] if b64[0] == "fromCharCode" else b64[0]
tmp = []
for c in b64:
  # Only run the deobfuscator if it's a character
  if c.isalpha():
    n = if_true if c <= "Z" else if_false
    c = ord(c) + add_unconditionally
    tmp.append(chr(c) if n >= c else chr(c - sub_unconditionally))
  else:
    tmp.append(c)
  decoded = json.loads(base64.b64decode("".join(tmp)))
```
*I see through your bullshit, JB.*


Anyway, they have an API that's very bare but works for getting chapter pages, so that monstrosity is now 2 lines. 

Also, meta tag changes and cache timing changes for the pages.