### PR TITLE
Preload image flash fix for Safari.

### DIFF
--- a/reader/static/css/main.css
+++ b/reader/static/css/main.css
@@ -2086,15 +2086,15 @@ _:-webkit-full-screen:not(:root:root), .fit_height_limit .rdr-image-wrap .Reader
 }*/
 
 .preload-entity {
-	visibility: hidden;
+	opacity: 0.1;
 	z-index: -1;
-	max-width: 100vw;
-	max-height: 50vh;
 	position: absolute;
+	width: 24px;
+	height: 24px;
+	overflow: scroll;
 	top: 0;
 	left: 0;
 	pointer-events: none;
-	background-size: 0px 0px;
 }
 
 .disabled {

--- a/reader/templates/reader/reader.html
+++ b/reader/templates/reader/reader.html
@@ -54,7 +54,9 @@
 	height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 	<!-- End Google Tag Manager (noscript) -->
 	<main id="rdr-main" class="" tabindex="-1">
-		<img class="preload-entity" id="scan_line" data-bind="preload_entity">
+		<div class="preload-entity">
+			<img id="scan_line" data-bind="preload_entity">
+		</div>
 		<aside>
 			<div class="hide-side" data-bind="sidebar_button"><div class="hide-side-actual is-ico-button"></div></div>
 			<header>


### PR DESCRIPTION
Here ya go, `4b8ca05cb7b806960675621dd771c5f8`.

It seems if the `div` is too small or has 0 visibility then it doesn't interact properly with css transforms to preload the image. JB/MD handles their images by setting the src on one div (rather than transforms), and that's how it seems they don't see any of the flashing issues.

Tested on Safari, Chrome stable, FF preview and FF stable and confirmed that the behaviour is now consistent.