### PR TITLE
Use python3

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Django's command-line utility for administrative tasks."""
 import os
 import sys


### PR DESCRIPTION
On many UNIX systems, python —> system python2. This uses python3. 