### PR TITLE
Simplify the installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,12 @@ Testing Supported By<br/>
 ⚠ **Note:** The install instructions below will not result in a general purpose CMS due to the amount of hardcoded assets in Guyamoe.
 
 ## Prerequisites 
-
 - git
 - python 3.6.5+
 - pip
 - virtualenv
 
 ## Install
-
 1. Create a venv for Guyamoe in your home directory.
 ```
 virtualenv ~/guyamoe
@@ -37,17 +35,17 @@ pip3 install -r requirements.txt
 
 5. Change the value of the `SECRET_KEY` variable to a randomly generated string.
 ```
-sed -i "s|\"o kawaii koto\"|\"$(openssl rand -base64 32)\"|" ./guyamoe/settings/base.py
+sed -i "s|\"o kawaii koto\"|\"$(openssl rand -base64 32)\"|" guyamoe/settings/base.py
 ```
 
 6. Generate the default assets for Guyamoe.
 ```
-python3 ./init.py
+python3 init.py
 ```
 
 7. Create an admin user for Guyamoe.
 ```
-python3 ./manage.py createsuperuser
+python3 manage.py createsuperuser
 ```
 
 Before starting the server, create a `media` folder in the base directory. Add manga with the corresponding chapters and page images. Structure it like so:
@@ -62,16 +60,14 @@ media
 ```
 E.g. `Kaguya-Wants-To-Be-Confessed-To` for `<series-slug-name>`. 
 
-Note: Zero pad chapter folder numbers like so: `001` for the Kaguya series (this is how the fixtures data for the series has it). It doesn't matter for pages though nor does it have to be .jpg. Only thing required for pages is that the ordering can be known from a simple numerical/alphabetical sort on the directory.
+**Note:** Zero pad chapter folder numbers like so: `001` for the Kaguya series (this is how the fixtures data for the series has it). It doesn't matter for pages though nor does it have to be .jpg. Only thing required for pages is that the ordering can be known from a simple numerical/alphabetical sort on the directory.
 
 ## Start the server
-
--  `python3 ./manage.py runserver` - keep this console active
+-  `python3 manage.py runserver` - keep this console active
 
 Now the site should be accessible on localhost:8000
 
 ## Other info
-
 Relevant URLs (as of now): 
 
 - `/` - home page

--- a/README.md
+++ b/README.md
@@ -15,41 +15,39 @@ Testing Supported By<br/>
 
 ## Install
 
-1. Create a virtualenv for Guyamoe in the current user's home directory.
+1. Create a venv for Guyamoe in your home directory.
 ```
-virtualenv "${HOME}"/guyamoe
-```
-
-2. Clone this repository into the virtualenv.
-```
-git clone https://github.com/appu1232/guyamoe "${HOME}"/guyamoe/app
+virtualenv ~/guyamoe
 ```
 
-3. Activate the virtualenv.
+2. Clone Guyamoe's source code into the venv.
 ```
-source "${HOME}"/guyamoe/bin/activate
+git clone https://github.com/appu1232/guyamoe ~/guyamoe/app
+```
+
+3. Activate the venv.
+```
+cd ~/guyamoe/app && source ../bin/activate
 ```
 
 4. Install Guyamoe's dependencies.
 ```
-pip3 install -r "${HOME}"/guyamoe/app/requirements.txt
+pip3 install -r requirements.txt
 ```
 
 5. Change the value of the `SECRET_KEY` variable to a randomly generated string.
 ```
-sed -i "s|os.environ.get(\"SECRET_KEY\", \"o kawaii koto\")|\"$(openssl rand -base64 32)\"|g" "${HOME}"/guyamoe/app/guyamoe/settings/base.py
+sed -i "s|\"o kawaii koto\"|\"$(openssl rand -base64 32)\"|" ./guyamoe/settings/base.py
 ```
 
 6. Generate the default assets for Guyamoe.
 ```
-sed -i 's|os.system("python -u manage.py runserver 0.0.0.0:8000")|#os.system("python -u manage.py runserver 0.0.0.0:8000")|g' "${HOME}"/guyamoe/app/docker/init.py
-cd "${HOME}"/guyamoe/app
-python3 "${HOME}"/guyamoe/app/docker/init.py
+python3 ./init.py
 ```
 
 7. Create an admin user for Guyamoe.
 ```
-python3 "${HOME}"/guyamoe/app/manage.py createsuperuser
+python3 ./manage.py createsuperuser
 ```
 
 Before starting the server, create a `media` folder in the base directory. Add manga with the corresponding chapters and page images. Structure it like so:
@@ -68,7 +66,7 @@ Note: Zero pad chapter folder numbers like so: `001` for the Kaguya series (this
 
 ## Start the server
 
--  `python3 "${HOME}"/guyamoe/app/manage.py runserver` - keep this console active
+-  `python3 ./manage.py runserver` - keep this console active
 
 Now the site should be accessible on localhost:8000
 

--- a/init.py
+++ b/init.py
@@ -1,0 +1,118 @@
+import json
+import os
+import random
+import subprocess
+import time
+from multiprocessing import Pool
+
+from PIL import Image, ImageDraw, ImageFilter
+
+WIDTH = 850
+HEIGHT = 1250
+PAGES = 18
+PROCESSES = 15
+
+MEDIA_BASE = "media"
+FIXTURES_PATH = "./reader/fixtures/reader_fixtures.json"
+
+
+def real_path(path):
+    return os.path.join(MEDIA_BASE, path)
+
+
+def generate_image(path):
+    if not os.path.isfile(real_path(path)):
+        print("Generating", path)
+        width = WIDTH
+        height = HEIGHT
+        if "shrunk" in path:
+            width = 85
+            height = 125
+        img = Image.new(
+            "RGB",
+            (width, height),
+            color=(
+                random.randint(0, 255),
+                random.randint(0, 255),
+                random.randint(0, 255),
+            ),
+        )
+        ImageDraw.Draw(img).text(
+            (width / 2, height / 2), path.split("/")[-1], fill=(0, 0, 0)
+        )
+        if "blur" in path:
+            img.filter(ImageFilter.GaussianBlur(radius=10))
+        img.save(real_path(path))
+        return True
+
+
+def create_directories(directories):
+    for directory in directories:
+        os.makedirs(real_path(directory), exist_ok=True)
+
+
+def load_fixtures(path):
+    with open(path, "r") as fixtures:
+        raw = fixtures.read()
+        data = json.loads(raw)
+
+        series = {}
+        for d in data:
+            if d["model"] == "reader.series":
+                series[d["pk"]] = d["fields"]["slug"]
+
+        directories = []
+        volume_covers = []
+        chapters = []
+        for d in data:
+            f = d["fields"]
+            if d["model"] == "reader.chapter":
+                directories.append(
+                    f"manga/{series[f['series']]}/chapters/{f['folder']}/{f['group']}"
+                )
+                directories.append(
+                    f"manga/{series[f['series']]}/chapters/{f['folder']}/{f['group']}_shrunk"
+                )
+                directories.append(
+                    f"manga/{series[f['series']]}/chapters/{f['folder']}/{f['group']}_shrunk_blur"
+                )
+                for page_num in range(1, PAGES + 1):
+                    chapters.append(
+                        f"manga/{series[f['series']]}/chapters/{f['folder']}/{f['group']}/{page_num:03}.jpg"
+                    )
+                    chapters.append(
+                        f"manga/{series[f['series']]}/chapters/{f['folder']}/{f['group']}_shrunk/{page_num:03}.jpg"
+                    )
+                    chapters.append(
+                        f"manga/{series[f['series']]}/chapters/{f['folder']}/{f['group']}_shrunk_blur/{page_num:03}.jpg"
+                    )
+
+            elif d["model"] == "reader.volume":
+                if f["volume_cover"]:
+                    directories.append("/".join(f["volume_cover"].split("/")[0:-1]))
+                    volume_covers.append(f["volume_cover"])
+
+        return {
+            "volume_covers": volume_covers,
+            "chapters": chapters,
+            "directories": directories,
+        }
+
+
+if __name__ == "__main__":
+    fixtures = load_fixtures(FIXTURES_PATH)
+    create_directories(fixtures["directories"])
+    with Pool(PROCESSES) as p:
+        changed = [
+            status
+            for status in p.map(
+                generate_image, fixtures["chapters"] + fixtures["volume_covers"]
+            )
+            if status
+        ]
+
+    os.system("python manage.py makemigrations")
+    result = subprocess.check_output("python manage.py migrate", shell=True, text=True)
+
+    if "OK" in result or changed:
+        os.system(f"python manage.py loaddata {FIXTURES_PATH}")


### PR DESCRIPTION
This pull request simplifies the installation instructions by

- changing `"${HOME}"` to `~/`
- shortening the random string generation command
- creating a separate `init.py` file without the `runserver` command for non-Docker installations