### PR TITLE
Fix STATIC_VERSION to work with paths with spaces

### DIFF
--- a/guyamoe/settings/base.py
+++ b/guyamoe/settings/base.py
@@ -140,7 +140,7 @@ STATICFILES_DIRS = [
 ]
 
 STATIC_VERSION = "?v=" + subprocess.check_output(
-    f"git -C {BASE_DIR} rev-parse --short HEAD", shell=True, text=True
+    ['git', '-C', BASE_DIR, 'rev-parse', '--short', 'HEAD'], text=True
 )
 
 MEDIA_URL = "/media/"

--- a/guyamoe/settings/base.py
+++ b/guyamoe/settings/base.py
@@ -140,7 +140,7 @@ STATICFILES_DIRS = [
 ]
 
 STATIC_VERSION = "?v=" + subprocess.check_output(
-    ['git', '-C', BASE_DIR, 'rev-parse', '--short', 'HEAD'], text=True
+    ["git", "-C", str(BASE_DIR), "rev-parse", "--short", "HEAD"], text=True
 )
 
 MEDIA_URL = "/media/"


### PR DESCRIPTION
The previous code didn't work with paths with spaces.
It also used shell=True for some reason when it's not exactly needed.