### PR TITLE
Add a setting to disable tapping to go to the next page.

### DIFF
--- a/reader/static/js/init.js
+++ b/reader/static/js/init.js
@@ -955,7 +955,7 @@ function SettingsHandler(){
 		},
 		help: {
 			true: `When ${IS_MOBILE ? 'tapping' : 'clicking'}, the page turns depending on the direction.`,
-			false: 'Tapping on the page does not turn it.',
+			false: `${IS_MOBILE ? 'Tapping' : 'Clicking'} on the page does not turn it.`,
 		},
 		default: true,
 		compact: true,

--- a/reader/static/js/init.js
+++ b/reader/static/js/init.js
@@ -947,6 +947,21 @@ function SettingsHandler(){
 		global: false
 	})
 	.newSetting({
+		addr: 'bhv.clickTurnPage',
+		prettyName: `Turn page by ${IS_MOBILE ? 'tapping' : 'clicking'}`,
+		strings: {
+			true: 'Turn page',
+			false: 'Disabled',
+		},
+		help: {
+			true: `When ${IS_MOBILE ? 'tapping' : 'clicking'}, the page turns depending on the direction.`,
+			false: 'Tapping on the page does not turn it.',
+		},
+		default: true,
+		compact: true,
+		type: SETTING_BOOLEAN,
+	})
+	.newSetting({
 		addr: 'bhv.historyUpdate',
 		prettyName: 'Browser history/back button behavior',
 		options: ['none','replace','chap','jump', 'all'],
@@ -2214,6 +2229,7 @@ const SCROLL_X = 3;
 			return;
 		}
 		if(e.button != 0) return;
+		if(Settings.get('bhv.clickTurnPage') === false) return;
 	var box = this.$.getBoundingClientRect();
 	var areas = [
 			0,


### PR DESCRIPTION
On my mobile device it's annoying to zoom in on a page since I sometimes accidentally trigger the next or previous page. I also rarely ever really tap to go to the next or previous page.

This adds a setting to disable tapping/clicking to the next page. 

There should probably be another setting to remove the magic constant for the swipe sensitive as well and make it configurable (many readers support this) however I didn't know where to start.

I'm also unsure if I was missing something when adding this setting but I did test this out locally on both my phone and my desktop with no problems.