### PR TITLE
Cleanup zip_chapter to remove unnecessary database calls

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -320,8 +320,13 @@ def chapter_post_process(chapter, is_update=True):
     blur = os.path.join(chapter_folder, f"{group}_shrunk_blur")
     os.makedirs(shrunk, exist_ok=True)
     os.makedirs(blur, exist_ok=True)
-    [os.remove(os.path.join(chapter_folder, shrunk, f)) for f in os.listdir(shrunk)]
-    [os.remove(os.path.join(chapter_folder, blur, f)) for f in os.listdir(blur)]
+
+    for f in os.listdir(shrunk):
+        os.remove(os.path.join(chapter_folder, shrunk, f))
+
+    for f in os.listdir(blur):
+        os.remove(os.path.join(chapter_folder, blur, f))
+
     all_pages = os.listdir(os.path.join(chapter_folder, group))
     for idx, page in enumerate(all_pages):
         create_preview_pages(chapter_folder, group, page)

--- a/api/api.py
+++ b/api/api.py
@@ -325,7 +325,7 @@ def chapter_post_process(chapter, is_update=True):
     all_pages = os.listdir(os.path.join(chapter_folder, group))
     for idx, page in enumerate(all_pages):
         create_preview_pages(chapter_folder, group, page)
-    zip_chapter(chapter.series.slug, chapter.chapter_number, chapter.group)
+    zip_chapter(chapter)
     if is_update:
         chapter.version = chapter.version + 1 if chapter.version else 2
         chapter.updated_on = datetime.utcnow().replace(tzinfo=timezone.utc)
@@ -357,18 +357,16 @@ def clear_pages_cache():
     cache.set("peak_traffic", peak_traffic, 3600 * 6)
 
 
-def zip_chapter(series_slug, chapter, group):
-    ch_obj = Chapter.objects.filter(
-        series__slug=series_slug, chapter_number=chapter, group=group
-    ).first()
+def zip_chapter(chapter: Chapter):
     chapter_dir = os.path.join(
-        settings.MEDIA_ROOT, "manga", series_slug, "chapters", ch_obj.folder
+        settings.MEDIA_ROOT, "manga", chapter.series.slug, "chapters", chapter.folder
     )
+    group_id = str(chapter.group.id)
     chapter_pages = [
-        os.path.join(chapter_dir, str(group.id), f)
-        for f in os.listdir(os.path.join(chapter_dir, str(group.id)))
+        os.path.join(chapter_dir, group_id, f)
+        for f in os.listdir(os.path.join(chapter_dir, group_id))
     ]
-    zip_filename = f"{ch_obj.group.id}_{ch_obj.slug_chapter_number()}.zip"
+    zip_filename = f"{chapter.group.id}_{chapter.slug_chapter_number()}.zip"
     zf = zipfile.ZipFile(os.path.join(chapter_dir, zip_filename), "w")
     for fpath in chapter_pages:
         _, fname = os.path.split(fpath)

--- a/api/api.py
+++ b/api/api.py
@@ -311,7 +311,7 @@ def index_chapter(chapter):
         )
 
 
-def chapter_post_process(chapter, is_update=True):
+def chapter_post_process(chapter, is_update=True, *, save_zip=True):
     chapter_folder = os.path.join(
         settings.MEDIA_ROOT, "manga", chapter.series.slug, "chapters", chapter.folder
     )
@@ -330,7 +330,10 @@ def chapter_post_process(chapter, is_update=True):
     all_pages = os.listdir(os.path.join(chapter_folder, group))
     for idx, page in enumerate(all_pages):
         create_preview_pages(chapter_folder, group, page)
-    zip_chapter(chapter)
+
+    if save_zip:
+        zip_chapter(chapter)
+
     if is_update:
         chapter.version = chapter.version + 1 if chapter.version else 2
         chapter.updated_on = datetime.utcnow().replace(tzinfo=timezone.utc)

--- a/api/views.py
+++ b/api/views.py
@@ -146,7 +146,7 @@ def download_chapter(request, series_slug, chapter):
         with open(os.path.join(chapter_dir, zip_chapter_file), "rb") as f:
             zip_file = f.read()
     else:
-        zip_file, _, _ = zip_chapter(series_slug, chapter_number, ch_obj.group)
+        zip_file, _, _ = zip_chapter(ch_obj)
     resp = HttpResponse(zip_file, content_type="application/x-zip-compressed")
     resp[
         "Content-Disposition"


### PR DESCRIPTION
This PR does 3 closely related things.

1. It removes the extraneous database call from `zip_chapter` since all its callers already had the chapter object as a pre-requisite.
2. Removes weird list comprehensions that were glorified for loops.
3. Adds a `save_zip` keyword argument to `chapter_post_process` in case a scraper does not necessarily want to zip up the folder into their storage. Useful for local deployments.

It's mainly just minor clean-up.
