### PR TITLE
Remove deprecated usage of unescape

### DIFF
--- a/reader/static/js/init.js
+++ b/reader/static/js/init.js
@@ -1205,8 +1205,8 @@ function UI_Reader(o) {
 		if(slug) this.SCP.series = slug;
 		this.SCP.lastChapter = this.current.chaptersIndex[this.current.chaptersIndex.length - 1];
 		this.SCP.firstChapter = this.current.chaptersIndex[0];
-		let path = window.location.pathname.split("/").map(e => unescape(e));
-		this._.title.innerHTML = `<a href="${path.splice(0, path.indexOf(unescape(this.current.slug))).join("/")}/${this.current.slug}/">${this.current.title}</a>`;
+		let path = window.location.pathname.split("/").map(e => decodeURIComponent(e));
+		this._.title.innerHTML = `<a href="${path.splice(0, path.indexOf(decodeURIComponent(this.current.slug))).join("/")}/${this.current.slug}/">${this.current.title}</a>`;
 		this.$.querySelector('aside').classList.remove('unload');
 	var chapterElements = [];
 	var volElements = {};
@@ -1420,7 +1420,7 @@ function UI_Reader(o) {
 		&& !this.SCP.chapterObject.notice){
 			let source = window.location.pathname.split("/");
 			source = source[source.indexOf(this.SCP.series) - 1];
-			globalHistoryHandler.addChapter(unescape(this.SCP.series), source, this.SCP.chapter.toString());
+			globalHistoryHandler.addChapter(decodeURIComponent(this.SCP.series), source, this.SCP.chapter.toString());
 		}
 		this.S.out('SCP', this.SCP);
 	}


### PR DESCRIPTION
This should be using decodeURIComponent instead. To demonstrate why:

```js
>> encodeURIComponent("お前")
<- "%E3%81%8A%E5%89%8D"
>> decodeURIComponent("%E3%81%8A%E5%89%8D")
<- "お前"
>> unescape("%E3%81%8A%E5%89%8D")
<- "ã\u0081\u008aå\u0089\u008d"
```

This causes the title innerHTML to break a URL since it can't find
the proper path to splice, giving you a 404 if the series has
characters outside of the ASCII range.