### PR TITLE
Use page description in template and reduce duplication of meta tags.

### DIFF
--- a/homepage/templates/homepage/how_cute_404.html
+++ b/homepage/templates/homepage/how_cute_404.html
@@ -46,7 +46,7 @@
 </style>
 <html>
 	<head>
-		<title>{{ brand.name }} :: 404</title>
+		<title>404 :: {{ brand.name }}</title>
 		<meta name="twitter:description" content="{{ brand.description }}" />
 		<meta property="og:description" content="{{ brand.description }}">
 		<meta name="description" content="{{ brand.description }}">

--- a/misc/templates/misc/misc.html
+++ b/misc/templates/misc/misc.html
@@ -1,11 +1,11 @@
 {% extends "layout.html" %}
 {% load page_tags %}
 {% load static %}
-{% block head %}
-<title>{{ page_title }} | Guya.moe</title>
-<meta name="twitter:description" content="{{ content | convert_to_markdown | striptags | truncatewords:40 }}" />
-<meta property="og:description" content="{{ content | convert_to_markdown | striptags | truncatewords:40 }}" />
-<meta name="description" content="{{ content | convert_to_markdown | striptags | truncatewords:40 }}">
+{% block meta %}
+<title>{{ brand.name }} :: {{ page_title }}</title>
+<meta name="twitter:description" content="{{ page_description }}" />
+<meta property="og:description" content="{{ page_description }}" />
+<meta name="description" content="{{ page_description }}">
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:title" content="{{page_title}}" />
 <meta name="twitter:image" content="{{cover_image_url}}" />

--- a/misc/templates/misc/misc.html
+++ b/misc/templates/misc/misc.html
@@ -2,7 +2,7 @@
 {% load page_tags %}
 {% load static %}
 {% block meta %}
-<title>{{ brand.name }} :: {{ page_title }}</title>
+<title>{{ page_title }} :: {{ brand.name }}</title>
 <meta name="twitter:description" content="{{ page_description }}" />
 <meta property="og:description" content="{{ page_description }}" />
 <meta name="description" content="{{ page_description }}">

--- a/misc/views.py
+++ b/misc/views.py
@@ -50,7 +50,7 @@ def content(request, page_url):
         content = content.replace("{{%s}}" % var.key, var.value)
     template_tags = {
         "content": content,
-        "preview": page.preview,
+        "page_description": page.preview,
         "page_url": page.page_url,
         "page_title": page.page_title,
         "date": int(page.date.timestamp()) if page.date else "",

--- a/reader/templates/reader/reader.html
+++ b/reader/templates/reader/reader.html
@@ -4,16 +4,16 @@
 <head>
   <meta charset="UTF-8">
   <meta name="theme-color" content="#2b2f33" />
-  <title>{{ brand.name }} :: {{ series_name }} :: Chapter {{ chapter_number }}</title>
-  <meta name="twitter:title" content="{{ brand.name }} :: {{ series_name }} :: Chapter {{ chapter_number }}">
-  <meta property="og:title" content="{{ brand.name }} :: {{ series_name }} :: Chapter {{ chapter_number }}">
-  <meta name="description" content="{{ brand.name }} :: Read chapter {{ chapter_number }} of {{ series_name }}">
+  <title>{{ series_name }} :: Chapter {{ chapter_number }} :: {{ brand.name }}</title>
+  <meta name="twitter:title" content="{{ series_name }} :: Chapter {{ chapter_number }} :: {{ brand.name }}">
+  <meta property="og:title" content="{{ series_name }} :: Chapter {{ chapter_number }} :: {{ brand.name }}">
+  <meta name="description" content="Read chapter {{ chapter_number }} of {{ series_name }} :: {{ brand.name }}">
   <meta name="twitter:card" content="summary">
   {% if first_party %}
   <meta property="og:description"
-    content="{{ brand.name }} :: Read chapter {{ chapter_number }} of {{ series_name }}">
+    content="Read chapter {{ chapter_number }} of {{ series_name }} :: {{ brand.name }}">
   <meta name="twitter:description"
-    content="{{ brand.name }} :: Read chapter {{ chapter_number }} of {{ series_name }}">
+    content="Read chapter {{ chapter_number }} of {{ series_name }} :: {{ brand.name }}">
   <meta property="og:image" content="{{ brand.image_url }}">
   <meta name="twitter:image" content="{{ brand.image_url }}">
   <meta name="author" content="{{ author_name }}">

--- a/reader/templates/reader/series.html
+++ b/reader/templates/reader/series.html
@@ -1,11 +1,11 @@
 {% extends "layout.html" %} {% load static %}
 {% block meta %}
-<title>{{ brand.name }} :: Read {{ series }}</title>
+<title>Read {{ series }} :: {{ brand.name }}</title>
 <meta name="twitter:description" content="Read {{ series }} manga series by {{ author }}" />
 <meta property="og:description" content="Read {{ series }} manga series by {{ author }}" />
 <meta name="description" content="Read {{ series }} manga series by {{ author }}.{{ alt_titles_str|safe }}" />
 <meta name="twitter:card" content="summary" />
-<meta name="twitter:title" content="{{ brand.name }} :: Read {{ series }}" />
+<meta name="twitter:title" content="Read {{ series }} :: {{ brand.name }}" />
 <meta name="twitter:image" content="{{ brand.image_url }}" />
 <meta property="og:image" content="{{ brand.image_url }}" />
 <meta name="author" content="{{ author }}" />

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -24,7 +24,7 @@
 	<meta name="format-detection" content="telephone=no">
   {% block meta %}
   {% if page_title %}
-  <title>{{ brand.name }} :: {{ page_title }}</title>
+  <title>{{ page_title }} :: {{ brand.name }}</title>
   {% else %}
   <title>{{ brand.name }}</title>
   {% endif %}


### PR DESCRIPTION
I don't have any pages to actually test this with. I don't know how the layout of the page.preview is like to need the extraneous filters but if they're necessary I can add them.