### PR TITLE
A bunch of fixes to the admin panel and others

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -133,15 +133,16 @@ def random_chars():
     return "".join(random.choices("0123456789abcdefghijklmnopqrstuvwxyz", k=8))
 
 
-def delete_chapter_pages_if_exists(folder_path, clean_chapter_number, group_id):
-    group_id = str(group_id)
-    shutil.rmtree(os.path.join(folder_path, group_id), ignore_errors=True)
-    shutil.rmtree(os.path.join(folder_path, f"{group_id}_shrunk"), ignore_errors=True)
+def delete_chapter_pages_if_exists(folder_path, clean_chapter_number, group_folder):
+    group_id = str(group_folder)
+    shutil.rmtree(os.path.join(folder_path, group_folder), ignore_errors=True)
+    shutil.rmtree(os.path.join(folder_path, f"{group_folder}_shrunk"), ignore_errors=True)
     shutil.rmtree(
-        os.path.join(folder_path, f"{group_id}_shrunk_blur"), ignore_errors=True
+        os.path.join(folder_path, f"{group_folder}_shrunk_blur"), ignore_errors=True
     )
-    if os.path.exists(os.path.join(folder_path, f"{str(clean_chapter_number)}.zip")):
-        os.remove(os.path.join(folder_path, f"{str(clean_chapter_number)}.zip"))
+    if os.path.exists(os.path.join(folder_path, f"{group_folder}_{slug_chapter_number}.zip")):
+        os.remove(os.path.join(folder_path, f"{group_folder}_{slug_chapter_number}.zip"))
+
 
 
 def create_chapter_obj(

--- a/reader/management/commands/chapter_sanity_check.py
+++ b/reader/management/commands/chapter_sanity_check.py
@@ -1,0 +1,40 @@
+from django.core.management.base import BaseCommand
+
+from reader.models import Chapter, Volume
+from django.conf import settings
+
+import os
+
+def is_a_not_empty_folder(path):
+    if not os.path.exists(path):
+        raise RuntimeError(f"'{path}' does not exist")
+    if not os.path.isdir(path):
+        raise RuntimeError(f"'{path}' is not a dir")
+    if len(os.listdir(path)) == 0:
+        raise RuntimeError(f"'{path}' is empty.")
+
+class Command(BaseCommand):
+    help = "Check that the file for every chapter do exist at the correct location"
+
+    def add_arguments(self, parser):
+        pass
+
+    def handle(self, *args, **options):
+        for chapter in Chapter.objects.select_related("series", "group"):
+            series_folder = os.path.join(settings.MEDIA_ROOT, "manga", chapter.series.slug)
+            chapter_folder = os.path.join(series_folder, "chapters", chapter.folder)
+            group_folder = str(chapter.group.id)
+            is_a_not_empty_folder(series_folder)
+            is_a_not_empty_folder(chapter_folder)
+            is_a_not_empty_folder(os.path.join(chapter_folder, f"{group_folder}"))
+            is_a_not_empty_folder(os.path.join(chapter_folder, f"{group_folder}_shrunk"))
+            is_a_not_empty_folder(os.path.join(chapter_folder, f"{group_folder}_shrunk_blur"))
+            print(chapter_folder, "is ok.")
+
+        for volume in Volume.objects.select_related("series"):
+            series_folder = os.path.join(settings.MEDIA_ROOT, str(volume.volume_cover))
+
+            if not os.path.exists(series_folder):
+                raise RuntimeError(f"'{series_folder}' does not exist")
+
+        print("Success!")

--- a/reader/models.py
+++ b/reader/models.py
@@ -1,5 +1,6 @@
 import os
 from datetime import datetime, timezone
+from random import randint
 
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey
@@ -33,6 +34,23 @@ class Group(models.Model):
 
 def embed_image_path(instance, filename):
     return os.path.join("manga", instance.slug, "static", str(filename))
+
+
+def new_volume_folder(instance):
+    return os.path.join(
+        "manga",
+        instance.series.slug,
+        "volume_covers",
+        str(instance.volume_number),
+    )
+
+def new_volume_path_file_name(instance, filename):
+    _, ext = os.path.splitext(filename)
+    new_filename = str(randint(10000, 99999)) + ext
+    return os.path.join(
+        new_volume_folder(instance),
+        new_filename,
+    )
 
 
 class Series(models.Model):
@@ -95,6 +113,7 @@ class Series(models.Model):
 
     class Meta:
         ordering = ("name",)
+        verbose_name_plural = "series"
 
 
 def path_file_name(instance, filename):
@@ -112,7 +131,7 @@ class Volume(models.Model):
     series = models.ForeignKey(
         Series, blank=False, null=False, on_delete=models.CASCADE
     )
-    volume_cover = models.ImageField(blank=True, upload_to=path_file_name)
+    volume_cover = models.ImageField(blank=True, upload_to=new_volume_path_file_name)
 
     class Meta:
         unique_together = (

--- a/reader/models.py
+++ b/reader/models.py
@@ -116,16 +116,6 @@ class Series(models.Model):
         verbose_name_plural = "series"
 
 
-def path_file_name(instance, filename):
-    return os.path.join(
-        "manga",
-        instance.series.slug,
-        "volume_covers",
-        str(instance.volume_number),
-        filename,
-    )
-
-
 class Volume(models.Model):
     volume_number = models.PositiveIntegerField(blank=False, null=False, db_index=True)
     series = models.ForeignKey(

--- a/reader/signals.py
+++ b/reader/signals.py
@@ -4,16 +4,12 @@ from datetime import datetime, timedelta, timezone
 
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
-from django.db.models.signals import post_delete, post_save, pre_save
+from django.db.models.signals import post_delete, post_save, pre_save, post_init
 from django.dispatch import receiver
 from PIL import Image, ImageFilter
 
-from api.api import (
-    clear_pages_cache,
-    delete_chapter_pages_if_exists,
-    chapter_post_process,
-)
-from reader.models import Chapter, HitCount, Series, Volume
+from api.api import clear_pages_cache, delete_chapter_pages_if_exists
+from reader.models import Chapter, HitCount, Series, Volume, new_volume_folder
 
 
 @receiver(post_delete, sender=Series)
@@ -38,7 +34,7 @@ def delete_chapter_folder(sender, instance, **kwargs):
             instance.folder,
         )
         delete_chapter_pages_if_exists(
-            folder_path, instance.clean_chapter_number(), instance.group.id
+            folder_path, instance.clean_chapter_number(), str(instance.group.id)
         )
         if os.path.exists(folder_path) and not os.listdir(folder_path):
             shutil.rmtree(folder_path, ignore_errors=True)
@@ -48,6 +44,7 @@ def delete_chapter_folder(sender, instance, **kwargs):
         ).first()
         if hit_count_obj:
             hit_count_obj.delete()
+        clear_pages_cache()
 
 
 @receiver(post_delete, sender=Volume)
@@ -70,6 +67,7 @@ def pre_save_chapter(sender, instance, **kwargs):
         instance.reprocess_metadata = False
         instance.save()
         chapter_post_process(instance, is_update=False)
+
     if instance.series and instance.series.next_release_page:
         highest_chapter_number = Chapter.objects.filter(series=instance.series).latest(
             "chapter_number"
@@ -80,18 +78,70 @@ def pre_save_chapter(sender, instance, **kwargs):
             ) + timedelta(days=7)
             instance.series.save()
 
+@receiver(post_init, sender=Chapter)
+def remember_original_series_of_chapter(sender, instance, **kwargs):
+    instance.old_chapter_number = str(instance.slug_chapter_number()) if instance.chapter_number is not None else None
+    instance.old_series_slug = str(instance.series.slug) if hasattr(instance, 'series') else None
+    instance.old_group_id = str(instance.group.id) if hasattr(instance, 'group') else None
+
 
 @receiver(post_save, sender=Chapter)
 def post_save_chapter(sender, instance, **kwargs):
+    # If the group or series or the chapter number has changed, move all chapter file
+    if (instance.old_series_slug is not None and str(instance.series.slug) != instance.old_series_slug) or \
+       (instance.old_group_id is not None and str(instance.group.id) != instance.old_group_id) or \
+       (instance.old_chapter_number is not None and str(instance.slug_chapter_number()) != instance.old_chapter_number):
+
+        new_group_id = str(instance.group.id)
+
+        old_chapter_folder = os.path.join(settings.MEDIA_ROOT, "manga", instance.old_series_slug, "chapters", instance.folder, instance.old_group_id)
+        new_chapter_folder = os.path.join(settings.MEDIA_ROOT, "manga", instance.series.slug, "chapters", instance.folder, new_group_id)
+
+        os.makedirs(os.path.dirname(new_chapter_folder), exist_ok=True)
+        if old_chapter_folder != new_chapter_folder or str(instance.slug_chapter_number()) != instance.old_chapter_number:
+            shutil.move(f"{old_chapter_folder}_{instance.old_chapter_number}.zip", f"{new_chapter_folder}_{instance.slug_chapter_number()}.zip")
+
+        if old_chapter_folder != new_chapter_folder:
+            shutil.move(old_chapter_folder, new_chapter_folder)
+            shutil.move(f"{old_chapter_folder}_shrunk", f"{new_chapter_folder}_shrunk")
+            shutil.move(f"{old_chapter_folder}_shrunk_blur", f"{new_chapter_folder}_shrunk_blur")
+
     if instance.series:
         clear_pages_cache()
 
+
+@receiver(post_init, sender=Volume)
+def remember_original_series_of_volume(sender, instance, **kwargs):
+    instance.old_series_slug = str(instance.series.slug) if hasattr(instance, 'series') else None
+    instance.old_volume_number = int(instance.volume_number) if instance.volume_number else None
+    instance.old_volume_cover = None if instance.volume_cover is None else str(instance.volume_cover)
 
 @receiver(post_save, sender=Volume)
 def save_volume(sender, instance, **kwargs):
     if instance.series:
         clear_pages_cache()
-    if instance.volume_cover:
+    if instance.volume_cover is None or instance.volume_cover == "":
+        return
+    # If series has been changed or the volume has been changed, move images
+    # and a cover has been set in the past and a new cover has not been uploaded
+    if instance.old_series_slug is not None and (instance.old_series_slug != str(instance.series.slug) or instance.old_volume_number != int(instance.volume_number)) \
+        and instance.old_volume_cover is not None and instance.old_volume_cover == instance.volume_cover:
+        old_location = os.path.join(settings.MEDIA_ROOT, os.path.dirname(str(instance.old_volume_cover)))
+        new_location = os.path.join(settings.MEDIA_ROOT, new_volume_folder(instance))
+        if os.path.normpath(old_location) != os.path.normpath(new_location):
+            os.makedirs(new_location, exist_ok=True)
+            for file in os.listdir(old_location):
+                os.rename(os.path.join(old_location, file), os.path.join(new_location, file))
+            os.rmdir(old_location)
+            original_filename = os.path.basename(str(instance.volume_cover))
+            instance.volume_cover = os.path.join(new_volume_folder(instance), original_filename)
+
+            # setup it up to prevent a recursive loop of save call back
+            instance.old_series_slug = str(instance.series.slug)
+            instance.old_volume_number = int(instance.volume_number)
+            instance.old_volume_cover = str(instance.volume_cover)
+            instance.save()
+    elif instance.volume_cover and (instance.old_volume_cover is None or instance.old_volume_cover != instance.volume_cover):
         save_dir = os.path.join(os.path.dirname(str(instance.volume_cover)))
         vol_cover = os.path.basename(str(instance.volume_cover))
         for old_data in os.listdir(os.path.join(settings.MEDIA_ROOT, save_dir)):
@@ -105,7 +155,8 @@ def save_volume(sender, instance, **kwargs):
             quality=60,
             method=6,
         )
-        image.save(os.path.join(settings.MEDIA_ROOT, save_dir, f"{filename}.jp2"))
+        # This line crash on my server and this file does not seem be used at all.
+        # image.save(os.path.join(settings.MEDIA_ROOT, save_dir, f"{filename}.jp2"))
         blur = Image.open(os.path.join(settings.MEDIA_ROOT, save_dir, vol_cover))
         blur = blur.convert("RGB")
         blur.thumbnail((blur.width / 8, blur.height / 8), Image.ANTIALIAS)

--- a/reader/views.py
+++ b/reader/views.py
@@ -53,7 +53,6 @@ def hit_count(request):
     return HttpResponse(json.dumps({}), content_type="application/json")
 
 
-@cache_control(public=True, max_age=60, s_maxage=60)
 def series_page_data(request, series_slug):
     series_page_dt = cache.get(f"series_page_dt_{series_slug}")
     if not series_page_dt:


### PR DESCRIPTION
- Fix issue where changing the group or the series of a chapter would break stuff
- Fix issue where doing anything to the volume would break stuff
- Fix delete chapter, didn't delete the .zip
- Add chapter_sanity_check, a script to confirm that the location of all the file in the database is consistent with what's in the media/ folder
- Upload path for covers does not use the original filename anymore, instead a random number is used, so the CDN/cache is happy
- Fix plural of series in admin panel

You can still break everything by changing the series' slug, though.