### PR TITLE
Fix annoying manga-card behaviour

### DIFF
--- a/static_global/css/index.css
+++ b/static_global/css/index.css
@@ -463,10 +463,20 @@ main a {
 	background-size: 1500px;
 	background-position: 50% 10%;
 }
-.manga-card.bigg picture img { 
-	height: 30em;
-	width: 20.4em;
+
+.manga-card.bigg picture img,
+.manga-card.bigg > .picture {
+    height:30em;
+    width:20.4em;
 }
+
+@media (max-width: 768px) {
+    .manga-card.bigg .picture {
+        width: 7.5em;
+        height: 11em;
+    }
+}
+
 .manga-card {
 	min-height: 9em;
 }
@@ -493,19 +503,6 @@ main a {
 .manga-card > * {
 	z-index: 2;
 	position: relative;
-}
-
-.manga-card.bigg picture img,
-.manga-card.bigg > .picture {
-    height:30em;
-    width:20.4em;
-}
-
-@media (max-width: 768px) {
-    .manga-card.bigg .picture {
-        width: 7.5em;
-        height: 11em;
-    }
 }
 
 .manga-card > a.picture,

--- a/static_global/css/index.css
+++ b/static_global/css/index.css
@@ -495,6 +495,19 @@ main a {
 	position: relative;
 }
 
+.manga-card.bigg picture img,
+.manga-card.bigg > .picture {
+    height:30em;
+    width:20.4em;
+}
+
+@media (max-width: 768px) {
+    .manga-card.bigg .picture {
+        width: 7.5em;
+        height: 11em;
+    }
+}
+
 .manga-card > a.picture,
 .manga-card > picture {
 	display: inline-block;


### PR DESCRIPTION
As the `.manga-card.bigg > .picture` element content is inserted via JavaScript, while the script doesn't load, it's width is 0. When JavaScript loads (and inserts the content), the card width is calculated, which cause an annoying layout change.
This PR fix the issue by setting an initial width to the card. These GIFs bellow demonstrate the difference (sorry for the crappy image quality!):
Before the fix:
![old](https://user-images.githubusercontent.com/37017117/139562437-884570e3-34e3-4728-9421-1cc8ddb454fd.gif)
After the fix:
![new](https://user-images.githubusercontent.com/37017117/139562444-61299409-b781-46cc-8964-67bd85cc7b33.gif)
This PR also lower the [Cumulative Layout Shift](https://web.dev/cls/)

